### PR TITLE
Handle simple non-dict dependency

### DIFF
--- a/ansiblerolesgraph/__init__.py
+++ b/ansiblerolesgraph/__init__.py
@@ -78,7 +78,10 @@ def parse_roles(roles_dirs, builder=GraphBuilder()):
 
             with open(path, 'r') as f:
                 for dependency in yaml.load(f.read())['dependencies']:
-                    depended_role = dependency['role']
+                    if isinstance(dependency, dict):
+                        depended_role = dependency['role']
+                    else:
+                        depended_role = dependency
 
                     builder.add_role(depended_role)
                     builder.link_roles(dependent_role, depended_role)


### PR DESCRIPTION
There are 2 supported ways to specify a dependency in Ansible:

```
dependencies:
  - simple-string
  - { role: complex, tags: ['something'], when: condition }
```

This adds support for the simple case
