### PR TITLE
tolerate empty dependencies in a role & the lightweight syntax

### DIFF
--- a/ansiblerolesgraph/__init__.py
+++ b/ansiblerolesgraph/__init__.py
@@ -77,9 +77,12 @@ def parse_roles(roles_dirs, builder=GraphBuilder()):
             builder.add_role(dependent_role)
 
             with open(path, 'r') as f:
-                for dependency in yaml.load(f.read())['dependencies']:
-                    depended_role = dependency['role']
-
+                for dependency in yaml.load(f.read()).get('dependencies', []):
+                    if type(dependency) == type(""):
+                        depended_role = dependency # simplified syntax
+                    else:
+                        depended_role = dependency['role']
+                    
                     builder.add_role(depended_role)
                     builder.link_roles(dependent_role, depended_role)
 


### PR DESCRIPTION
Hi,

first of all, thanks for this tool!

This PR adjusts the load-time behaviour so that roles with an empty meta/main.yml and roles using the simplified syntax will still load

Thanks in advance